### PR TITLE
Fix documentation issues from React-Select v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reason bindings for react-select
 
-[Reason](https://reasonml.github.io/) bindings for [react-select](https://github.com/JedWatson/react-select).
+[Reason](https://reasonml.github.io/) bindings for [react-select](https://github.com/JedWatson/react-select/tree/v1.x).
 
 ## Status
 
@@ -32,9 +32,10 @@ To include styles
 ## TODO
 
 * [ ] `aria-describedby` / `aria-label` / `aria-labelledby` SpecialCreationFunction doesn't allow to change prop name, hopefully this will be possible in the next bucklescript releases
-* [ ] Annotate [Async props](https://github.com/JedWatson/react-select#async-props)
-* [ ] Annotate [Creatable props](https://github.com/JedWatson/react-select#creatable-properties)
-* [ ] can we reduce boilerplate in `Select.re` and `SelectMulti.re`?
+* [ ] Annotate [Async props](https://github.com/JedWatson/react-select/tree/v1.x#async-options)
+* [ ] Annotate [Creatable props](https://github.com/JedWatson/react-select/tree/v1.x#creatable-properties)
+* [ ] Can we reduce boilerplate in `Select.re` and `SelectMulti.re`?
+* [ ] Upgrade to react-select version 2
 * [x] `resetValue` / `value` - string | 'a OR string | array('a)
 * [x] `filterOptions` - bool | func
 * [x] Separate SelectMulti


### PR DESCRIPTION
Author completely rewrote the library two months ago, see https://github.com/JedWatson/react-select/tree/master#version-2-.

This fixes links to use V1, and adds a TODO for upgrading.

-- 
Note: in no way do I want to suggest you yourself have to do this rewrite to V2. Intent of this PR is only to help users know there's a difference and that we use v1. 

If I have some time, for example, I'd be interested in scoping how hard the rewrite would be and potentially doing.